### PR TITLE
Fixes the CRC32 calculation for FINGERPRINT

### DIFF
--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -6,7 +6,7 @@ use crate::checks::*;
 use crate::message::*;
 
 use anyhow::Result;
-use crc::{Crc, CRC_32_ISCSI};
+use crc::{Crc, CRC_32_ISO_HDLC};
 
 // FingerprintAttr represents FINGERPRINT attribute.
 //
@@ -31,7 +31,7 @@ const FINGERPRINT_SIZE: usize = 4; // 32 bit
 // the 32-bit value 0x5354554e (the XOR helps in cases where an
 // application packet is also using CRC-32 in it).
 pub fn fingerprint_value(b: &[u8]) -> u32 {
-    let checksum = Crc::<u32>::new(&CRC_32_ISCSI).checksum(b);
+    let checksum = Crc::<u32>::new(&CRC_32_ISO_HDLC).checksum(b);
     checksum ^ FINGERPRINT_XOR_VALUE // XOR
 }
 

--- a/src/fingerprint/fingerprint_test.rs
+++ b/src/fingerprint/fingerprint_test.rs
@@ -4,6 +4,27 @@ use crate::textattrs::TextAttribute;
 use crate::attributes::ATTR_SOFTWARE;
 
 #[test]
+fn fingerprint_uses_crc_32_iso_hdlc() -> Result<()> {
+    let mut m = Message::new();
+
+    let a = TextAttribute {
+        attr: ATTR_SOFTWARE,
+        text: "software".to_owned(),
+    };
+    a.add_to(&mut m)?;
+    m.write_header();
+
+    FINGERPRINT.add_to(&mut m)?;
+    m.write_header();
+
+    assert_eq!(&m.raw[0..m.raw.len()-8], b"\x00\x00\x00\x14\x21\x12\xA4\x42\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x22\x00\x08\x73\x6F\x66\x74\x77\x61\x72\x65");
+
+    assert_eq!(m.raw[m.raw.len() - 4..], [0xe4, 0x4c, 0x33, 0xd9]);
+
+    Ok(())
+}
+
+#[test]
 fn test_fingerprint_check() -> Result<()> {
     let mut m = Message::new();
     let a = TextAttribute {


### PR DESCRIPTION
Added a golden-standard unit test for fingerprint calculation. The hardcoded expected value on the unit test was calculated using boost's C++ implementation of CRC32. This code was fixed by using CRC_32_ISO_HDLC algorithm on CRC calculation.

This fixes https://github.com/webrtc-rs/webrtc/issues/75