### PR TITLE
update deps + loosen some requirements

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,24 +10,39 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and test
+  check_and_test:
+    name: Check and test
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        toolchain:
+          - 1.56.1 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
+          - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
+      - uses: actions/checkout@v3
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
 
   rustfmt_and_clippy:
-    name: Check rustfmt style && run clippy
+    name: Check rustfmt style and run clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -35,7 +50,7 @@ jobs:
           components: clippy, rustfmt
           override: true
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -43,6 +58,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -D warnings
       - name: Check formating
         uses: actions-rs/cargo@v1
         with:
@@ -56,7 +72,7 @@ jobs:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
@@ -48,3 +48,22 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -69,7 +69,11 @@ jobs:
     name: Compile and test with minimal versions
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        # TODO: add 'windows-latest' once criterion#atty version is upgraded
+        # "0.2" min version (0.2.0) depends on winapi-0.2.4 which does not
+        # compile on nightly.
+        # https://github.com/bheisler/criterion.rs/pull/587
+        os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,20 @@ bench = []
 
 [dependencies]
 util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["conn"] }
-tokio = { version = "1.15.0", features = ["full"] }
-lazy_static = "1.4.0"
-url = "2.2.2"
-rand = "0.8.4"
+tokio = { version = "1.19", features = ["full"] }
+lazy_static = "1.4"
+url = "2.2"
+rand = "0.8.5"
 base64 = "0.13.0"
-subtle = "2.4.1"
-crc = "2.1.0"
+subtle = "2.4"
+crc = "3.0"
 ring = "0.16.20"
-md-5 = "0.10.0"
-thiserror = "1.0.30"
+md-5 = "0.10.1"
+thiserror = "1.0"
 
 [dev-dependencies]
-tokio-test = "0.4.2"
-clap = "2.34.0"
+tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
+clap = "3.2.6"
 criterion = "0.3.5"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 bench = []
 
 [dependencies]
-util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["conn"] }
+util = { package = "webrtc-util", version = "0.5.4", default-features = false, features = ["conn"] }
 tokio = { version = "1.19", features = ["full"] }
 lazy_static = "1.4"
 url = "2.2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -299,15 +299,14 @@ impl Client {
                         t.remove(&id);
                     }
                     EventType::Callback(id) => {
-                        let mut ct;
-                        if t.contains_key(&id) {
-                            ct = t.remove(&id).unwrap();
+                        let mut ct = if t.contains_key(&id) {
+                            t.remove(&id).unwrap()
                         } else {
                             /*if c.handler != nil && !errors.Is(e.Error, ErrTransactionStopped) {
                                 c.handler(e)
                             }*/
                             continue;
-                        }
+                        };
 
                         if ct.attempt >= max_attempts || event.event_body.is_ok() {
                             if let Some(handler) = ct.handler {


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version
  (unless crates readme says otherwise)
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions
  (unless crates readme says otherwise) OR specify major&minor
  versions otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions